### PR TITLE
Adds Larastan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
+  - php vendor/bin/phpstan analyse
   - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": "^7.1",
         "cboden/ratchet": "^0.4.1",
         "guzzlehttp/guzzle": "^6.3",
-        "laravel/dusk": "^4.0",
-        "nunomaduro/larastan": "^0.3.8"
+        "laravel/dusk": "^4.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
+        "nunomaduro/larastan": "^0.3.8",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": "^7.1",
         "cboden/ratchet": "^0.4.1",
         "guzzlehttp/guzzle": "^6.3",
-        "laravel/dusk": "^4.0"
+        "laravel/dusk": "^4.0",
+        "nunomaduro/larastan": "^0.3.8"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+includes:
+    - ./vendor/nunomaduro/larastan/extension.neon
+parameters:
+    level: 5
+    paths:
+        - src
+    excludes_analyse:
+        - %rootDir%/../../../src/Ratchet/App.php

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -23,7 +23,9 @@ class Browser extends BaseBrowser
     }
 
     /**
-     * {@inheritdoc}
+     * @param  string $url
+     *
+     * @return  \BeyondCode\DuskDashboard\Browser
      */
     public function visit($url)
     {

--- a/src/Console/StartDashboardCommand.php
+++ b/src/Console/StartDashboardCommand.php
@@ -49,10 +49,10 @@ class StartDashboardCommand extends Command
 
         $socket = new Socket();
 
-        $app = new App($url['host'], $this->option('port'), '0.0.0.0', $loop);
+        $app = new App($url['host'], (int) $this->option('port'), '0.0.0.0', $loop);
         $app->route('/socket', new WsServer($socket), ['*']);
-        $app->routes->add('events', new Route('/events', ['_controller' => new Events()], [], [], null, [], ['POST']));
-        $app->routes->add('dashboard', new Route('/dashboard', ['_controller' => new DashboardController()], [], [], null, [], ['GET']));
+        $app->routes->add('events', new Route('/events', ['_controller' => new Events()], [], [], '', [], ['POST']));
+        $app->routes->add('dashboard', new Route('/dashboard', ['_controller' => new DashboardController()], [], [], '', [], ['GET']));
         $app->run();
     }
 }

--- a/src/Ratchet/HttpServer.php
+++ b/src/Ratchet/HttpServer.php
@@ -8,6 +8,8 @@ class HttpServer extends \Ratchet\Http\HttpServer
 {
     public function __construct(HttpServerInterface $component)
     {
+        parent::__construct($component);
+
         $this->_httpServer = $component;
         $this->_reqParser = new HttpRequestParser;
     }


### PR DESCRIPTION
This Pull Request adds [nunomaduro/larastan](http://github.com/nunomaduro/larastan) as `require-dev` dependency. Larastan is a wrapper of PHPStan, and is a **static analysis** tool for PHP.

About Phpstan: "_PHPStan is a static analysis tool for PHP code. It parses your code and tries to find flaws in the program logic (like a variable being used before being declared, or a function being called that does not exist...). It is not the ultimate tool for catching bugs but it has one huge advantage: it does not need a lot work to set up! No need to write unit tests, simply run the tool and it will output a list of potential errors!_".

You can read more in this article: [medium.com/@ondrejmirtes/phpstan-2939cd0ad0e3](https://medium.com/@ondrejmirtes/phpstan-2939cd0ad0e3)

This **Pull Request also fixes the errors detected until level `5`**.

Usage:
```bash
./vendor/bin/phpstan analyse
```
<img width="100%" alt="example" src="https://user-images.githubusercontent.com/5457236/47382339-5faed580-d702-11e8-9c46-9c3158f20ccf.png">

Notes:
- You can choose from currently 8 levels: (0 is the loosest and 7 is the strictest) by passing `--level` option: `./vendor/bin/phpstan analyse --level=5`.
- **Larastan is not stable yet**. But I am using it in all my projects and packages.
- The line `./vendor/bin/phpstan analyse` was added to `.travis` file.
