### PR TITLE
Fix method signature to comply with the interface implemented by the class

### DIFF
--- a/src/Ratchet/Socket.php
+++ b/src/Ratchet/Socket.php
@@ -4,6 +4,7 @@ namespace BeyondCode\DuskDashboard\Ratchet;
 
 use Ratchet\ConnectionInterface;
 use Symfony\Component\Process\Process;
+use Ratchet\RFC6455\Messaging\MessageInterface;
 use Ratchet\WebSocket\MessageComponentInterface;
 
 class Socket implements MessageComponentInterface
@@ -15,7 +16,7 @@ class Socket implements MessageComponentInterface
         self::$connections[] = $connection;
     }
 
-    public function onMessage(ConnectionInterface $from, $msg)
+    public function onMessage(ConnectionInterface $from, MessageInterface $msg)
     {
         $data = json_decode($msg);
 


### PR DESCRIPTION
Hi!

First of all, thanks for this great tool!  🙂It's really going to improve automated browser testing with Laravel Dusk.

When running `php artisan dusk:dashboard` I get error that declaration of `onMessage` method on `BeyondCode\DuskDashboard\Ratchet\Socket` class is not compatible with the signature of `Ratchet\WebSocket\MessageCallableInterface` interface that is implemented through `Ratchet\WebSocketMessageComponentInterface`.

See the screenshot:
<img width="583" alt="screen shot 2018-12-13 at 2 58 21 pm" src="https://user-images.githubusercontent.com/13997617/49944366-8b705f80-feea-11e8-946b-05826a66a604.png">

This PR fixes that.

Thanks again!