### PR TITLE
Adds pathing entry to Usage section of docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ php artisan dusk:dashboard
 
 Check out the documentation [here](http://marcelpociot.de/blog/introducing-the-laravel-dusk-dashboard).
 
+### Handling Asset Paths
+
+Assets may not load or display properly when using relative paths due to port specification. Using Larvel's [Path Helpers](https://laravel.com/docs/5.7/helpers#available-methods) such as the `url()` and `asset()` helpers  (Ex: `{{ url('path/to/asset.css') }}`) will help overcome these pathing issues.
+
 ### Testing
 
 ``` bash


### PR DESCRIPTION
Lots of projects use relative paths for assets and I can foresee this being an issue that leaves new users scratching their heads. This snippet should help alleviate issues arising from this in the future - hopefully!