### PR TITLE
Use `open` command only on macOS as it is not available on other systems

### DIFF
--- a/src/Console/StartDashboardCommand.php
+++ b/src/Console/StartDashboardCommand.php
@@ -45,7 +45,7 @@ class StartDashboardCommand extends Command
 
             $this->info('If the dashboard does not automatically open, visit: '.$dashboardUrl);
 
-            exec('open '.$dashboardUrl);
+            $this->tryToOpenInBrowser($dashboardUrl);
         });
 
         $this->createTestWatcher();
@@ -117,5 +117,12 @@ class StartDashboardCommand extends Command
         $this->addRoutes();
 
         $this->app->run();
+    }
+
+    protected function tryToOpenInBrowser($url)
+    {
+        if (PHP_OS === 'Darwin') {
+            exec('open '.$url);
+        }
     }
 }


### PR DESCRIPTION
Since `open` command used to open dashboard in the browser is available only on macOS, an error is thrown on other operating systems.

This PR adds check to see if PHP is run on macOS before executing the `open` command.

