### PR TITLE
Proxy handling unsuccessful tests to the method on base class

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -85,6 +85,8 @@ abstract class TestCase extends BaseTestCase
             ]);
         } catch (\Exception $e) {
             // Dashboard is offline
+        } finally {
+            parent::onNotSuccessfulTest($t);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #16 

After notifying the dashboard of failed test we need to perform the same handling of that test as the base class would by proxying to the parent (in this case it just throws the Throwable).

Unless this is done, the test is seen as passing in the command line.

Cheers!