### PR TITLE
Added ability to configure the dashboard host

### DIFF
--- a/config/dusk-dashboard.php
+++ b/config/dusk-dashboard.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    /*
+     * You may specify which host the dashboard runs on in case it differs from the APP_URL
+     */
+    'host' => env('DUSK_DASHBOARD_URL', env('APP_URL', 'http://localhost')),
+];

--- a/src/Console/StartDashboardCommand.php
+++ b/src/Console/StartDashboardCommand.php
@@ -32,7 +32,7 @@ class StartDashboardCommand extends Command
 
     public function handle()
     {
-        $url = parse_url(config('app.url'));
+        $url = parse_url(config('dusk-dashboard.host', config('app.url')));
 
         $this->loop = LoopFactory::create();
 


### PR DESCRIPTION
Some of us use Dusk to interact with external websites or to test other local websites. This lets you configure the host the dashboard starts on

In my case after adding these modifications I simply added 

```
DUSK_DASHBOARD_URL=http://localhost
```

to my .env file