### PR TITLE
Pass Dashboard command arguments to Dusk when running it

### DIFF
--- a/src/Console/StartDashboardCommand.php
+++ b/src/Console/StartDashboardCommand.php
@@ -9,9 +9,9 @@ use React\EventLoop\LoopInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Route;
 use BeyondCode\DuskDashboard\Watcher;
-use Symfony\Component\Process\Process;
 use React\EventLoop\Factory as LoopFactory;
 use BeyondCode\DuskDashboard\Ratchet\Socket;
+use BeyondCode\DuskDashboard\DuskProcessFactory;
 use BeyondCode\DuskDashboard\Ratchet\Server\App;
 use BeyondCode\DuskDashboard\Ratchet\Http\EventController;
 use BeyondCode\DuskDashboard\Ratchet\Http\DashboardController;
@@ -23,6 +23,18 @@ class StartDashboardCommand extends Command
     protected $signature = 'dusk:dashboard';
 
     protected $description = 'Start the Laravel Dusk Dashboard';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->ignoreValidationErrors();
+    }
 
     /** @var App */
     protected $app;
@@ -83,7 +95,7 @@ class StartDashboardCommand extends Command
                 ])
             );
 
-            $process = new Process('php artisan dusk', base_path());
+            $process = DuskProcessFactory::make();
 
             $process->start();
         });

--- a/src/DuskProcessFactory.php
+++ b/src/DuskProcessFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BeyondCode\DuskDashboard;
+
+use Symfony\Component\Process\Process;
+
+class DuskProcessFactory
+{
+    /**
+     * Create new process to run Dusk, passing the same arguments Dashboard command received.
+     *
+     * @return \Symfony\Component\Process\Process
+     */
+    public static function make()
+    {
+        return new Process(array_merge(self::binary(), self::arguments()), base_path());
+    }
+
+    /**
+     * Dusk command represented as array.
+     *
+     * @return array
+     */
+    protected static function binary()
+    {
+        return [PHP_BINARY, 'artisan', 'dusk'];
+    }
+
+    /**
+     * Arguments that were given to dusk:dashboard.
+     *
+     * @return array
+     */
+    protected static function arguments()
+    {
+        return array_slice($_SERVER['argv'], 2);
+    }
+}

--- a/src/Ratchet/Socket.php
+++ b/src/Ratchet/Socket.php
@@ -3,8 +3,8 @@
 namespace BeyondCode\DuskDashboard\Ratchet;
 
 use Ratchet\ConnectionInterface;
-use Symfony\Component\Process\Process;
 use Ratchet\RFC6455\Messaging\MessageInterface;
+use BeyondCode\DuskDashboard\DuskProcessFactory;
 use Ratchet\WebSocket\MessageComponentInterface;
 
 class Socket implements MessageComponentInterface
@@ -21,7 +21,7 @@ class Socket implements MessageComponentInterface
         $data = json_decode($msg);
 
         if ($data->method === 'startTests') {
-            $process = new Process('php artisan dusk', base_path());
+            $process = DuskProcessFactory::make();
 
             $process->start();
         }


### PR DESCRIPTION
Currently there is no way to execute specific tests in the test suite when running through Dashboard, even though Dusk supports it.

By passing the parameters from `dusk:dashboard` command to `dusk` when starting the process we can allow this, as well as anything else dusk supports through command parameters.
This PR does just that.

Thanks for you time and all the best!