### PR TITLE
Replace  with jQuery() to be less intrusive

### DIFF
--- a/src/Dusk/Browser.php
+++ b/src/Dusk/Browser.php
@@ -72,14 +72,14 @@ class Browser extends \Laravel\Dusk\Browser
 
     protected function restoreHtml()
     {
-        $this->driver->executeScript("$('input').attr('value', function() { return $(this).val(); });");
+        $this->driver->executeScript("jQuery('input').attr('value', function() { return jQuery(this).val(); });");
 
-        $this->driver->executeScript("$('input[type=checkbox]').each(function() { $(this).attr('checked', $(this).prop(\"checked\")); });");
+        $this->driver->executeScript("jQuery('input[type=checkbox]').each(function() { jQuery(this).attr('checked', jQuery(this).prop(\"checked\")); });");
 
-        $this->driver->executeScript("$('textarea').each(function() { $(this).html($(this).val()); });");
+        $this->driver->executeScript("jQuery('textarea').each(function() { jQuery(this).html(jQuery(this).val()); });");
 
-        $this->driver->executeScript("$('input[type=radio]').each(function() { $(this).attr('checked', this.checked); });");
+        $this->driver->executeScript("jQuery('input[type=radio]').each(function() { jQuery(this).attr('checked', this.checked); });");
 
-        $this->driver->executeScript("$('select option').each(function() { $(this).attr('selected', this.selected); });");
+        $this->driver->executeScript("jQuery('select option').each(function() { jQuery(this).attr('selected', this.selected); });");
     }
 }


### PR DESCRIPTION
Hi,

This library uses the shorthand jQuery selector `$('...')`, while Dusk uses the regular selector `jQuery('...')`. When i tried this package on a working test it didn't gave me any output. After quite some debugging (as xdebug refused to work) it turned out that my application doesn't like the shorthand, while the normal works perfectly. I think this is because there is a `jQuery.noConflict()` somewhere, which removes the `$` alias.