### PR TITLE
Fix link to GIF in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A beautiful dashboard for your Dusk test suites.
 [![Quality Score](https://img.shields.io/scrutinizer/g/beyondcode/dusk-dashboard.svg?style=flat-square)](https://scrutinizer-ci.com/g/beyondcode/dusk-dashboard)
 [![Total Downloads](https://img.shields.io/packagist/dt/beyondcode/dusk-dashboard.svg?style=flat-square)](https://packagist.org/packages/beyondcode/dusk-dashboard)
 
-![](http://marcelpociot.de/user/pages/blog/introducing-the-laravel-dusk-dashboard/dusk-dashboard.gif)
+![](https://pociot.dev/storage/22/dusk-dashboard.gif)
 
 ## Installation
 


### PR DESCRIPTION
This is similar to #62, there is a GIF image that no longer works due to the domain change. 👍

Also, a heads up that the link on GitHub for the repository can be updated to https://pociot.dev/8-introducing-laravel-dusk-dashboard 🙂

![image](https://user-images.githubusercontent.com/1899334/74045807-5152fe80-49c5-11ea-9718-5a66f63c1e6f.png)
